### PR TITLE
[wip] デプロイの簡略化とフレームワークの稼働

### DIFF
--- a/bin/deploy_and_run.sh
+++ b/bin/deploy_and_run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+apihost=$1
+port=$2
+if [[ -z $port ]]; then
+  port=80
+fi
+
+if [[ -z $apihost ]]; then
+  apihost='172.31.22.45'
+fi
+
+git pull origin master
+php composer.phar update
+php -S ${apihost}:${port} index.php


### PR DESCRIPTION
apacheを通すとslim動かないので一旦各環境にビルトインwebサーバを立てます
さらにデプロイ時のphp compser.phar updateなどをやる起動スクリプトを作ります
個人環境のport開けて欲しい
- [x] ビルトインサーバ起動
- [x] composer udpate
